### PR TITLE
Add $JAVA_OPTS to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /app
 COPY . /app
 RUN ./gradlew bootJar
 EXPOSE 8080
-CMD java -jar build/libs/feelin-social-api.jar --spring.profiles.active=$APP_ENV --spring.config.additional-location=application-$APP_ENV.yml
+CMD java $JAVA_OPTS -jar build/libs/feelin-social-api.jar --spring.profiles.active=$APP_ENV --spring.config.additional-location=application-$APP_ENV.yml


### PR DESCRIPTION
이제 wafflestudio-cluster 내의 모든 서비스에 해당 Pod 가 사용할 cpu, memory resources 를 안정적인 운영을 위해 지정하려고 하는데요.
JVM 의 경우 heap 을 container 에서 사용한 것의 init 1/64, max 1/4 로 잡는 것이 디폴트입니다.

때문에, memory 를 빡빡하게 잡아두고 아무 설정을 안 하면, container 내에서 쓸 수 있는 공간이 더 있는데도 heap 을 1/4 만 쓰게 됩니다.
https://github.com/wafflestudio/waffle-world/blob/main/apps/snutt-prod/snutt-ev/snutt-ev.yaml#L58-L59 때문에 이런 식으로 jvm option 을 주어서 container 공간의 80% 정도를 heap 으로 할당하게 하고 있습니다. 이렇게 하면 비교적 가성비 좋게 spring 을 운영할 수 있습니다.

이러기 위해서는 Docker ENTRYPOINT 나 CMD 에 환경변수를 이용하는 부분이 있어야해서 추가했습니다.